### PR TITLE
Change text file logging directive

### DIFF
--- a/config/malzoo.conf.dist
+++ b/config/malzoo.conf.dist
@@ -10,7 +10,7 @@ whitelist   = jpg,png,txt,gif,jpeg
 yara_rules  = data/yara_rules/
 userdb      = data/userdb.txt
 # log results to text file
-text_log    = no
+textlog    = no
 # storage of samples
 storesample = no
 repository  = storage/


### PR DESCRIPTION
/malzoo/common/abstract.py line 40 is expecting configuration directive "textlog" but "text_log" is present in malzoo.conf.dist